### PR TITLE
Add basic multi-tenant support

### DIFF
--- a/app/Http/Middleware/IdentifyTenant.php
+++ b/app/Http/Middleware/IdentifyTenant.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Tenant;
+use App\TenantContext;
+use Closure;
+use Illuminate\Http\Request;
+
+class IdentifyTenant
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $tenantId = (int) $request->header('X-Tenant-ID', 0);
+        if ($tenantId) {
+            TenantContext::setTenantId($tenantId);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tenant extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Traits\BelongsToTenant;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, BelongsToTenant;
 
     /**
      * The attributes that are mass assignable.
@@ -21,6 +22,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'tenant_id',
     ];
 
     /**

--- a/app/TenantContext.php
+++ b/app/TenantContext.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App;
+
+class TenantContext
+{
+    protected static ?int $tenantId = null;
+
+    public static function setTenantId(?int $tenantId): void
+    {
+        self::$tenantId = $tenantId;
+    }
+
+    public static function getTenantId(): ?int
+    {
+        return self::$tenantId;
+    }
+}

--- a/app/Traits/BelongsToTenant.php
+++ b/app/Traits/BelongsToTenant.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Scope;
+use App\Models\Tenant;
+use App\TenantContext;
+
+class TenantScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $tenantId = TenantContext::getTenantId();
+        if ($tenantId) {
+            $builder->where($model->getTable() . '.tenant_id', $tenantId);
+        }
+    }
+}
+
+trait BelongsToTenant
+{
+    public static function bootBelongsToTenant(): void
+    {
+        static::creating(function (Model $model): void {
+            if (! $model->tenant_id) {
+                $model->tenant_id = TenantContext::getTenantId();
+            }
+        });
+
+        static::addGlobalScope(new TenantScope());
+    }
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->append(App\Http\Middleware\IdentifyTenant::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
@@ -23,12 +24,14 @@ return new class extends Migration
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {
             $table->string('email')->primary();
+            $table->unsignedBigInteger('tenant_id');
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });
 
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
             $table->foreignId('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();

--- a/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -13,12 +13,14 @@ return new class extends Migration
     {
         Schema::create('cache', function (Blueprint $table) {
             $table->string('key')->primary();
+            $table->unsignedBigInteger('tenant_id');
             $table->mediumText('value');
             $table->integer('expiration');
         });
 
         Schema::create('cache_locks', function (Blueprint $table) {
             $table->string('key')->primary();
+            $table->unsignedBigInteger('tenant_id');
             $table->string('owner');
             $table->integer('expiration');
         });

--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('jobs', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('tenant_id');
             $table->string('queue')->index();
             $table->longText('payload');
             $table->unsignedTinyInteger('attempts');
@@ -23,6 +24,7 @@ return new class extends Migration
 
         Schema::create('job_batches', function (Blueprint $table) {
             $table->string('id')->primary();
+            $table->unsignedBigInteger('tenant_id');
             $table->string('name');
             $table->integer('total_jobs');
             $table->integer('pending_jobs');
@@ -36,6 +38,7 @@ return new class extends Migration
 
         Schema::create('failed_jobs', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('tenant_id');
             $table->string('uuid')->unique();
             $table->text('connection');
             $table->text('queue');

--- a/database/migrations/0001_01_01_000003_create_tenants_table.php
+++ b/database/migrations/0001_01_01_000003_create_tenants_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tenants', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tenants');
+    }
+};


### PR DESCRIPTION
## Summary
- add middleware to detect tenant by request header
- track tenant id in TenantContext and models
- implement BelongsToTenant trait with global scope
- add Tenant model and migration
- include tenant_id in core migrations

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685075ac4efc8326a794446961632f94