### PR TITLE
Fix unique email constraint per tenant

### DIFF
--- a/database/migrations/0001_01_01_000004_create_users_table.php
+++ b/database/migrations/0001_01_01_000004_create_users_table.php
@@ -15,11 +15,13 @@ return new class extends Migration
             $table->id();
             $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
             $table->string('name');
-            $table->string('email')->unique();
+            $table->string('email');
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
+
+            $table->unique(['tenant_id', 'email']);
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {

--- a/database/migrations/2025_06_20_153500_update_users_email_index.php
+++ b/database/migrations/2025_06_20_153500_update_users_email_index.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['email']);
+            $table->unique(['tenant_id', 'email']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['tenant_id', 'email']);
+            $table->unique('email');
+        });
+    }
+};
+


### PR DESCRIPTION
## Summary
- allow duplicate emails across tenants
- add migration to drop old unique and set composite unique

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557f19951c8326a2ad36a3e06612fa