### PR TITLE
Register tenant permissions middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -33,6 +33,7 @@ class Kernel extends HttpKernel
 
         'api' => [
             'identify.tenant',
+            'settenant.permissions',
             // Aquí puedes agregar rate limiting si quieres:
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
@@ -55,6 +56,7 @@ class Kernel extends HttpKernel
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         // Tu middleware multiempresa:
         'identify.tenant' => \App\Http\Middleware\IdentifyTenant::class,
+        'settenant.permissions' => \App\Http\Middleware\SetTenantForPermissions::class,
         // Otros middlewares personalizados...
     ];
 }

--- a/app/Http/Middleware/SetTenantForPermissions.php
+++ b/app/Http/Middleware/SetTenantForPermissions.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Spatie\Permission\PermissionRegistrar;
 
 class SetTenantForPermissions
 {


### PR DESCRIPTION
## Summary
- add missing `PermissionRegistrar` import
- register SetTenantForPermissions middleware for API requests

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685584f015508326bae848ae6e93384e