### PR TITLE
Fix destroy response

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -292,7 +292,7 @@ class UserController extends Controller
                 'user_id' => $user->id,
                 'tenant_id' => $tenantId,
             ]);
-            return response()->json(['message' => 'User deleted successfully.'], 204);
+            return response()->noContent();
         } catch (\Throwable $e) {
             Log::error('Error deleting user', [
                 'user_id' => $user->id,


### PR DESCRIPTION
## Summary
- return `response()->noContent()` from `UserController@destroy`

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685584f17b1483268c8b2aa99a87cbb8