### PR TITLE
Ensure tenant seeded and used in user factory

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\Tenant;
+use App\TenantContext;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -13,11 +15,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        // Ensure we have at least one tenant
+        $tenant = Tenant::first() ?? Tenant::create(['name' => 'Default Tenant']);
+
+        // Optionally set the context so factories auto assign the tenant_id
+        TenantContext::setTenantId($tenant->id);
 
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
+            'tenant_id' => $tenant->id,
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- create or fetch a tenant in the `DatabaseSeeder`
- seed the default user with that tenant ID
- set `TenantContext` for factory auto assignment

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6855b763219c832699f3c5f0991fdcd5