### PR TITLE
Add tenant_id to UserFactory

### DIFF
--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Tenant>
+ */
+class TenantFactory extends Factory
+{
+    protected $model = Tenant::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Tenant;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
@@ -23,7 +24,10 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $tenantId = Tenant::query()->inRandomOrder()->value('id');
+
         return [
+            'tenant_id' => $tenantId ?? Tenant::factory(),
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),


### PR DESCRIPTION
## Summary
- ensure test factories can create tenants
- associate users with a tenant by default

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b760bafc8326b6982a44ddd7ac0d